### PR TITLE
Clean up module-level boilerplate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@
 - Drop the dated 3D button decoration (`:box (:style released-button)`) and hardcoded hex colours from `adoc-command-face` and `adoc-complex-replacement-face`; inherit from `font-lock-builtin-face` instead.
 - `adoc-meta-hide-face` no longer hardcodes `gray75`/`gray25` foregrounds; it simply inherits from `adoc-meta-face` so the colour tracks the theme. Customise the face if you want hidden markup to fade further into the background.
 - Drop the self-referencing `(defvar adoc-X-face 'adoc-X-face)` boilerplate and the `adoc-delimiter` / `adoc-hide-delimiter` aliases. Font-lock keyword specs now quote face symbols directly. No user-visible change; this is purely an internal cleanup.
+- `adoc-show-version` is now a deprecated alias for `adoc-mode-version`, which is itself the interactive command (still also a `defconst` carrying the version string). The previous `defalias 'adoc-mode-version → adoc-show-version` indirection is gone.
+- `adoc-default-title-type` and `adoc-default-title-sub-type` now use a `choice` widget restricted to 1 or 2, replacing the open-ended `integer` type that allowed nonsensical values.
+- Internal cleanup: `(adoc-calc)` runs from the mode initialization function rather than at file load. `(require 'adoc-mode-tempo)` and `(require 'compile)` moved to the top of the file. Dead `(boundp …)` guards around the `compilation-error-regexp-alist` integration removed. Stale `;; TODO` comments cleaned up. No user-visible change.
 
 ### Bugs fixed
 

--- a/adoc-mode.el
+++ b/adoc-mode.el
@@ -43,8 +43,10 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'compile)
 (require 'subr-x)
 (require 'adoc-mode-image)
+(require 'adoc-mode-tempo)
 
 (defconst adoc-mode-version "0.8.0"
   "adoc mode version number.")
@@ -191,16 +193,16 @@ AsciiDoc config file would the probably be '^[<>]-{4,}$'"
                         (regexp :tag "start regexp")
                         (regexp :tag "end regexp")))))
 
-;; TODO: limit value range to 1 or 2
 (defcustom adoc-default-title-type 1
   "Default title type, see `adoc-title-descriptor'."
-  :type 'integer
+  :type '(choice (const :tag "One-line" 1)
+                 (const :tag "Two-line" 2))
   :group 'adoc)
 
-;; TODO: limit value range to 1 or 2
 (defcustom adoc-default-title-sub-type 1
   "Default title sub type, see `adoc-title-descriptor'."
-  :type 'integer
+  :type '(choice (const :tag "Only starting delimiter" 1)
+                 (const :tag "Starting and trailing delimiter" 2))
   :group 'adoc)
 
 (defcustom adoc-enable-two-line-title nil
@@ -388,8 +390,6 @@ customizable.")
 
 (defvar adoc-font-lock-keywords nil
   "Font lock keywords in adoc-mode buffers.")
-
-(defvar adoc-replacement-failed nil )
 
 (define-abbrev-table 'adoc-mode-abbrev-table ())
 
@@ -2070,8 +2070,7 @@ TEXTPROPS is an additional plist with textproperties."
                     (t (error "Invalid replacement type"))))
                 (o (when (stringp s)
                      (make-overlay (match-end 1) (match-end 1)))))
-           (setq adoc-replacement-failed (not o))
-           (unless adoc-replacement-failed
+           (when o
              (overlay-put o 'adoc-kw-replacement t)
              (overlay-put o 'after-string s))))
        found))
@@ -2775,12 +2774,12 @@ for multiline constructs to be matched."
    (list 'adoc-flf-meta-face-cleanup)))
 
 ;;;; interactively-callable commands
-(defun adoc-show-version ()
+(defun adoc-mode-version ()
   "Show the version number in the minibuffer."
   (interactive)
   (message "adoc-mode, version %s" adoc-mode-version))
 
-(defalias 'adoc-mode-version #'adoc-show-version)
+(define-obsolete-function-alias 'adoc-show-version #'adoc-mode-version "0.9")
 
 (defun adoc-goto-ref-label (id)
   "Goto the anchor defining the id ID."
@@ -2859,11 +2858,6 @@ ARG is 0, see `adoc-adjust-title-del'."
   (interactive "p")
   (adoc-promote-title (- arg)))
 
-;; TODO:
-;; - adjust while user is typing title
-;; - tempo template which uses already typed text to insert a 'new' title
-;; - auto convert one line title to two line title. is easy&fast to type, but
-;;   gives two line titles for those liking them
 (defun adoc-adjust-title-del ()
   "Adjusts underline length to match the length of the title's text.
 
@@ -2900,8 +2894,6 @@ new customization demands."
   (when (and font-lock-mode (eq major-mode 'adoc-mode))
     (font-lock-flush)
     (font-lock-ensure)))
-
-(require 'adoc-mode-tempo)
 
 ;;;; misc
 (defun adoc-insert-indented (str indent-level)
@@ -3034,9 +3026,6 @@ and title's text are not preserved, afterwards its always one space."
     (if (or create (not descriptor))
         (error "Point is not on a title"))
 
-    ;; TODO: set descriptor to default
-    ;; (if (not descriptor)
-    ;;     (setq descriptor (list 1 1 2 ?? adoc-default-title-type adoc-default-title-sub-type)))
     (let* ((type (nth 0 descriptor))
            (new-type-val (cond
                           ((eq new-type 1) 2)
@@ -3497,6 +3486,7 @@ Turning on Adoc mode runs the normal hook `adoc-mode-hook'."
   (setq-local paragraph-ignore-fill-prefix t)
 
   ;; font lock
+  (adoc-calc)
   (setq-local font-lock-defaults
               '(adoc-font-lock-keywords
                 nil nil nil nil
@@ -3527,22 +3517,17 @@ Turning on Adoc mode runs the normal hook `adoc-mode-hook'."
   (setq-local imenu-create-index-function adoc-imenu-create-index-function)
 
   ;; compilation
-  (when (boundp 'compilation-error-regexp-alist-alist)
-    (add-to-list 'compilation-error-regexp-alist-alist
-                 '(asciidoc
-                   "^asciidoc: +\\(?:ERROR\\|\\(WARNING\\|DEPRECATED\\)\\): +\\([^:\n]*\\): line +\\([0-9]+\\)"
-                   2 3 nil (1 . nil))))
-  (when (boundp 'compilation-error-regexp-alist)
-    (make-local-variable 'compilation-error-regexp-alist)
-    (add-to-list 'compilation-error-regexp-alist 'asciidoc))
+  (add-to-list 'compilation-error-regexp-alist-alist
+               '(asciidoc
+                 "^asciidoc: +\\(?:ERROR\\|\\(WARNING\\|DEPRECATED\\)\\): +\\([^:\n]*\\): line +\\([0-9]+\\)"
+                 2 3 nil (1 . nil)))
+  (setq-local compilation-error-regexp-alist
+              (cons 'asciidoc compilation-error-regexp-alist))
   (when (and (display-graphic-p) adoc-display-images)
     (adoc-display-images)))
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.a\\(?:scii\\)?doc\\'" . adoc-mode))
-
-;;;; non-definitions evaluated during load
-(adoc-calc)
 
 
 ;; Auto-fill


### PR DESCRIPTION
Phase 1 of a planned series of cleanup PRs ahead of larger modernization
work (`syntax-propertize-function`, `rx`, keymap/menu split). All
changes here are internal-only refactors with no user-visible behavior
change beyond the documented deprecation of `adoc-show-version`.

- `(require 'adoc-mode-tempo)` and `(require 'compile)` moved to the
  top of the file with the other requires.
- The mid-file `(require 'adoc-mode-tempo)` and the `(boundp ...)`
  guards around the `compilation-error-regexp-alist` integration are
  gone, since `compile.el` is now loaded eagerly.
- `(adoc-calc)` no longer runs at file load; it runs from the mode
  initialization function, where it belongs.
- `adoc-mode-version` is now the interactive command directly (the
  symbol already carried the version string via `defconst`).
  `adoc-show-version` is preserved as an obsolete alias.
- Dropped the unused `adoc-replacement-failed` defvar; the matcher
  uses a plain `(when o ...)` instead of the setq/unless dance.
- Tightened `:type` on `adoc-default-title-type` and
  `adoc-default-title-sub-type` from open-ended `integer` to a
  `choice` restricted to 1 or 2.
- Removed a handful of stale `;; TODO` comments.

All 55 tests still pass; byte-compile is clean.