### PR TITLE
Bump actions/checkout to v5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       run: curl -fsSL https://raw.github.com/doublep/eldev/master/webinstall/github-eldev | sh
 
     - name: Check out the source code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Test the project
       run: |


### PR DESCRIPTION
GitHub Actions warns that `actions/checkout@v4` runs on the deprecated Node.js 20 and will eventually stop working. Bumping to `@v5` (Node.js 24) clears the warning. No behavior change; CI on this PR exercises it across the full Emacs matrix.

- [x] The commits are consistent with our contribution guidelines
- [ ] You've added tests (if possible) to cover your change(s) — n/a, CI config only
- [x] All tests are passing (`eldev test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings — n/a, CI config only
- [ ] You've updated the changelog (if adding/changing user-visible functionality) — n/a
- [ ] You've updated the readme (if adding/changing user-visible functionality) — n/a