### PR TITLE
Complete over buffer anchors in adoc-goto-ref-label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Changes
 
+- `adoc-goto-ref-label` (`C-c C-a`) now completes over the anchors defined in the buffer instead of asking you to type the id blind. It stays permissive, so an id that isn't defined yet can still be entered, and the cross-reference at point is still offered as the default.
 - The compilation error matcher now also recognises modern `asciidoctor:` diagnostics, not just the legacy AsciiDoc.py `asciidoc:` format, so jumping to warnings and errors works with current Asciidoctor output.
 - `[source,ocaml]` code blocks now fontify with `neocaml-mode` when it is available, falling back to `tuareg-mode` and then `caml-mode`. To support this, a value in `adoc-code-lang-modes` may now be either a single major mode or a list of candidate modes tried in order (the first defined one wins).
 

--- a/README.adoc
+++ b/README.adoc
@@ -48,7 +48,7 @@ Here are some of the main features of `adoc-mode`:
 - heading navigation modelled on `markdown-mode` / `org-mode`: next / previous heading (`C-c C-n` / `C-c C-p`), forward / backward at the same level (`C-c C-f` / `C-c C-b`), and up to the parent heading (`C-c C-u`)
 - title management: promote / demote (`M-left` / `M-right`), toggle between one-line and two-line styles, adjust underline length
 - list editing: `M-left` / `M-right` nest the list item at point deeper or shallower, `M-RET` inserts a sibling item (incrementing the number for explicitly-numbered lists), `M-up` / `M-down` move an item (with its sub-items) past its siblings, and `M-x adoc-renumber-list` renumbers an explicitly-numbered list
-- navigate to anchors (`C-c C-a`) and follow URLs, `link:` and `include::` macros, and xrefs at point (`C-c C-o` / `M-.`), or by clicking them with the mouse
+- navigate to anchors with completion over the buffer's anchors (`C-c C-a`), and follow URLs, `link:` and `include::` macros, and xrefs at point (`C-c C-o` / `M-.`), or by clicking them with the mouse
 - an `xref` backend over anchors: `M-?` lists every cross-reference to the anchor at point, with the usual xref marker stack and completion UI
 - context-aware completion via `completion-at-point`: cross-reference ids inside `<<` / `xref:`, attribute names inside `{`, file paths after `include::`, and source-block languages inside `[source,`
 - nested `imenu` index with hierarchical heading structure

--- a/adoc-mode.el
+++ b/adoc-mode.el
@@ -2909,9 +2909,12 @@ for multiline constructs to be matched."
   (interactive (let* ((default (adoc-xref-id-at-point))
                       (default-str (if default (concat "(default " default ")") "")))
                  (list
-                  (read-string
+                  ;; Offer the buffer's anchors as candidates, but stay
+                  ;; permissive (require-match nil) so a not-yet-defined id can
+                  ;; still be entered.
+                  (completing-read
                    (concat "Goto anchor of reference/label " default-str ": ")
-                   nil nil default))))
+                   (adoc--collect-anchor-ids) nil nil nil nil default))))
   (let ((pos (save-excursion
                (goto-char (point-min))
                (re-search-forward (adoc-re-anchor nil id) nil t))))

--- a/test/adoc-mode-navigation-test.el
+++ b/test/adoc-mode-navigation-test.el
@@ -289,6 +289,22 @@
       (adoc-goto-ref-label "bar")
       (expect (line-number-at-pos) :to-equal 3)))
 
+  (it "offers the buffer's anchors when read interactively"
+    (with-temp-buffer
+      (adoc-mode)
+      (insert "[[alpha]]\n[[beta]]\nbody\n")
+      (goto-char (point-max))
+      (let (candidates)
+        (spy-on 'completing-read :and-call-fake
+                (lambda (_prompt collection &rest _)
+                  (setq candidates (all-completions "" collection))
+                  "alpha"))
+        (call-interactively #'adoc-goto-ref-label)
+        ;; the buffer's anchors were offered as candidates
+        (expect (sort candidates #'string<) :to-equal '("alpha" "beta"))
+        ;; and the chosen one was jumped to
+        (expect (line-number-at-pos) :to-equal 1))))
+
   (it "follows the block id shorthand, including the style#id form"
     (with-temp-buffer
       (adoc-mode)


### PR DESCRIPTION
Small ergonomics win: `adoc-goto-ref-label` (`C-c C-a`) used to make you type the anchor id from memory. Now it offers the buffer's anchors via `completing-read`, reusing the `adoc--collect-anchor-ids` collector from the completion work. It stays permissive (no `require-match`), so an id that isn't defined yet can still be entered, and the cross-reference at point is still the default.

This came out of a quick survey of which commands read from the minibuffer - `adoc-goto-ref-label` was the one clear candidate (the only other reads are `adoc-insert-link`'s URL/text, which have no good completion source).

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)