### PR TITLE
Render bold and emphasis as plain bold/italic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - `adoc-goto-ref-label` (`C-c C-a`) now completes over the anchors defined in the buffer instead of asking you to type the id blind. It stays permissive, so an id that isn't defined yet can still be entered, and the cross-reference at point is still offered as the default.
 - The compilation error matcher now also recognises modern `asciidoctor:` diagnostics, not just the legacy AsciiDoc.py `asciidoc:` format, so jumping to warnings and errors works with current Asciidoctor output.
 - `[source,ocaml]` code blocks now fontify with `neocaml-mode` when it is available, falling back to `tuareg-mode` and then `caml-mode`. To support this, a value in `adoc-code-lang-modes` may now be either a single major mode or a list of candidate modes tried in order (the first defined one wins).
+- Bold and emphasized text now use plain `bold` / `italic` faces instead of tinting the text with `adoc-gen-face`. This matches `asciidoc-mode` (and the convention in `markdown-mode` / `org-mode`), so switching between the modes is less jarring. Customize `adoc-bold-face` / `adoc-emphasis-face` if you preferred the tint.
 
 ### Bugs fixed
 

--- a/adoc-mode.el
+++ b/adoc-mode.el
@@ -673,13 +673,17 @@ or italic styling from a surrounding constrained quote."
   :group 'adoc-faces)
 
 (defface adoc-bold-face
-  '((t (:inherit (adoc-gen-face bold))))
-  "Face for bold text."
+  '((t (:inherit bold)))
+  "Face for bold text.
+Plain `bold' rather than a tinted face, matching `asciidoc-mode' and the
+convention in `markdown-mode' / `org-mode'."
   :group 'adoc-faces)
 
 (defface adoc-emphasis-face
-  '((t :inherit (adoc-gen-face italic)))
-  "For emphasized text."
+  '((t :inherit italic))
+  "For emphasized text.
+Plain `italic' rather than a tinted face, matching `asciidoc-mode' and the
+convention in `markdown-mode' / `org-mode'."
   :group 'adoc-faces)
 
 (defface adoc-markup-face

--- a/test/adoc-mode-font-lock-test.el
+++ b/test/adoc-mode-font-lock-test.el
@@ -61,6 +61,10 @@
       ("a __emph__ word"
        ("emph" adoc-emphasis-face)))
 
+    (it "keeps the bold and emphasis faces plain (no tint)"
+      (expect (face-attribute 'adoc-bold-face :inherit) :to-equal 'bold)
+      (expect (face-attribute 'adoc-emphasis-face :inherit) :to-equal 'italic))
+
     (when-fontifying-it "fontifies monospace via backticks"
       ("a `mono` word"
        ("mono" (adoc-typewriter-face adoc-verbatim-face))))


### PR DESCRIPTION
`adoc-bold-face` and `adoc-emphasis-face` inherited `adoc-gen-face`, which tints the text with the function-name color - and since that face is itself bold, `_emphasis_` came out bold-italic. asciidoc-mode and the wider ecosystem (markdown-mode, org-mode) render these plain.

Drop the tint so switching between adoc-mode and asciidoc-mode isn't jarring. Titles and other `adoc-gen-face` users are unaffected. Anyone who preferred the tint can customize the two faces back.